### PR TITLE
Add Goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,29 @@
+builds:
+  - main: ./cmd/connector/main.go
+    goos:
+      - darwin
+      - linux
+      - windows
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - "-s -w -X 'github.com/conduitio-labs/conduit-connector-google-sheets.version={{ .Tag }}'"
+checksum:
+  name_template: checksums.txt
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^go.mod:'
+      - '^.github:'
+      - Merge branch

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@ GOLINT := golangci-lint
 
 .PHONY: build test
 
+VERSION=$(shell git describe --tags --dirty --always)
+
 build:
-	go build -o conduit-connector-google-sheets cmd/connector/main.go
+	go build -ldflags "-X 'github.com/conduitio-labs/conduit-connector-google-sheets.version=${VERSION}'" -o conduit-connector-google-sheets cmd/connector/main.go
 	go build -o google-token-gen cmd/tokengen/main.go
 
 test:

--- a/spec.go
+++ b/spec.go
@@ -20,13 +20,18 @@ import (
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 
+// version is set during the build process (i.e. the Makefile).
+// It follows Go's convention for module version, where the version
+// starts with the letter v, followed by a semantic version.
+var version = "v0.0.0-dev"
+
 // Specification returns the Plugin's Specification.
 func Specification() sdk.Specification {
 	return sdk.Specification{
 		Name:        "google-sheets",
 		Summary:     "Google Sheets plugin",
 		Description: "A plugin capable of fetching records (in JSON format) from google spreadsheet.",
-		Version:     "v0.1.0",
+		Version:     version,
 		Author:      "Gophers Lab Technologies Pvt Ltd",
 	}
 }


### PR DESCRIPTION
This PR adds a goreleaser github action which releases the connector when a semantic version tag is pushed.